### PR TITLE
feat(kyvierno): enforce cluster security policies: no privileged, lab…

### DIFF
--- a/argocd/platform/kyverno/kyverno.yaml
+++ b/argocd/platform/kyverno/kyverno.yaml
@@ -1,0 +1,29 @@
+# Kyverno policy engine — validates and mutates resources against ClusterPolicies
+# Wave -1 — after namespaces (wave -3), before application workloads
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: platform
+  source:
+    repoURL: https://kyverno.github.io/kyverno/
+    chart: kyverno
+    targetRevision: 3.4.1
+    helm:
+      releaseName: kyverno
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argocd/platform/kyverno/policies.yaml
+++ b/argocd/platform/kyverno/policies.yaml
@@ -1,0 +1,26 @@
+# Kyverno ClusterPolicies — deployed after Kyverno CRDs are available
+# Wave 0 — Kyverno controller (wave -1) must be ready before policies sync
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno-policies
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/PodYourLife/k8s-platform.git
+    targetRevision: dev
+    path: kubernetes/policies
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/kubernetes/policies/check-image-registry.yaml
+++ b/kubernetes/policies/check-image-registry.yaml
@@ -1,0 +1,51 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-image-registry
+  annotations:
+    policies.kyverno.io/title: Check Image Registry
+    policies.kyverno.io/category: Supply Chain Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Restrict container images to ghcr.io/PodYourLife/ and a set of trusted
+      system registries. Runs in Audit mode during initial rollout.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: check-image-registry
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+                - argocd
+                - istio-system
+                - monitoring
+                - cert-manager
+      validate:
+        message: >-
+          Images must come from ghcr.io/PodYourLife/ or an allowed system registry.
+        foreach:
+          - list: "request.object.spec.[containers, initContainers, ephemeralContainers][]"
+            deny:
+              conditions:
+                all:
+                  - key: "{{ element.image }}"
+                    operator: NotEquals
+                    value: "ghcr.io/PodYourLife/*"
+                  - key: "{{ element.image }}"
+                    operator: NotEquals
+                    value: "docker.io/library/*"
+                  - key: "{{ element.image }}"
+                    operator: NotEquals
+                    value: "registry.k8s.io/*"
+                  - key: "{{ element.image }}"
+                    operator: NotEquals
+                    value: "quay.io/kiwigrid/*"

--- a/kubernetes/policies/disallow-privileged.yaml
+++ b/kubernetes/policies/disallow-privileged.yaml
@@ -1,0 +1,34 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-privileged-containers
+  annotations:
+    policies.kyverno.io/title: Disallow Privileged Containers
+    policies.kyverno.io/category: Pod Security
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Privileged containers can access all host devices and bypass most security
+      mechanisms. This policy denies any container that sets privileged: true.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: deny-privileged
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "Privileged containers are not allowed."
+        pattern:
+          spec:
+            containers:
+              - =(securityContext):
+                  =(privileged): "false"
+            =(initContainers):
+              - =(securityContext):
+                  =(privileged): "false"
+            =(ephemeralContainers):
+              - =(securityContext):
+                  =(privileged): "false"

--- a/kubernetes/policies/require-labels.yaml
+++ b/kubernetes/policies/require-labels.yaml
@@ -1,0 +1,37 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-labels
+  annotations:
+    policies.kyverno.io/title: Require Labels
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Require app.kubernetes.io/name and env labels on all Pods for consistent
+      observability and policy targeting. Runs in Audit mode during initial rollout.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: require-app-and-env-labels
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+                - argocd
+                - istio-system
+                - monitoring
+      validate:
+        message: "Pods must have 'app.kubernetes.io/name' and 'env' labels."
+        pattern:
+          metadata:
+            labels:
+              app.kubernetes.io/name: "?*"
+              env: "?*"


### PR DESCRIPTION
ArgoCD Applications (argocd/platform/kyverno/):
  - kyverno.yaml — Application (not ApplicationSet) deploying Kyverno Helm chart v3.4.1 from
  https://kyverno.github.io/kyverno/, namespace kyverno, sync wave -1, with CreateNamespace=true and
  ServerSideApply=true
  - policies.yaml — Application pointing to kubernetes/policies/, sync wave 0 (waits for Kyverno CRDs)

  ClusterPolicies (kubernetes/policies/):
  - disallow-privileged.yaml — Enforce mode, denies privileged: true on containers, initContainers, and
  ephemeralContainers
  - require-labels.yaml — Audit mode, requires app.kubernetes.io/name + env labels on Pods, exempts system namespaces
  - check-image-registry.yaml — Audit mode, allows only ghcr.io/PodYourLife/* plus trusted system images
  (docker.io/library/*, registry.k8s.io/*, quay.io/kiwigrid/*), exempts system namespaces including cert-manager