### PR TITLE
fix(argocd): replace hardcoded repoURL with __REPO_URL__ placeholder …

### DIFF
--- a/argocd/platform/argocd/servicemonitors.yaml
+++ b/argocd/platform/argocd/servicemonitors.yaml
@@ -19,6 +19,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'argocd-servicemonitors-{{.env}}'
@@ -30,7 +31,7 @@ spec:
     spec:
       project: platform
       source:
-        repoURL: https://github.com/PodYourLife/k8s-platform.git
+        repoURL: '{{.repoUrl}}'
         targetRevision: '{{.targetRevision}}'
         path: kubernetes/manifests/argocd/servicemonitors
       destination:

--- a/argocd/platform/cert-manager/issuer.yaml
+++ b/argocd/platform/cert-manager/issuer.yaml
@@ -18,6 +18,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'cert-manager-issuers-{{.env}}'
@@ -29,7 +30,7 @@ spec:
     spec:
       project: platform
       source:
-        repoURL: https://github.com/PodYourLife/k8s-platform.git
+        repoURL: '{{.repoUrl}}'
         targetRevision: '{{.targetRevision}}'
         path: kubernetes/manifests/cert-manager
       destination:

--- a/argocd/platform/development/servicemonitors.yaml
+++ b/argocd/platform/development/servicemonitors.yaml
@@ -24,6 +24,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'development-servicemonitors-{{.env}}'
@@ -35,7 +36,7 @@ spec:
     spec:
       project: platform
       source:
-        repoURL: https://github.com/PodYourLife/k8s-platform.git
+        repoURL: '{{.repoUrl}}'
         targetRevision: '{{.targetRevision}}'
         path: kubernetes/manifests/development/servicemonitors
       destination:

--- a/argocd/platform/istio/mesh-config.yaml
+++ b/argocd/platform/istio/mesh-config.yaml
@@ -17,6 +17,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'istio-mesh-config-{{.env}}'
@@ -28,7 +29,7 @@ spec:
     spec:
       project: platform
       source:
-        repoURL: https://github.com/PodYourLife/k8s-platform.git
+        repoURL: '{{.repoUrl}}'
         targetRevision: '{{.targetRevision}}'
         path: istio/helm
       destination:

--- a/argocd/platform/istio/security.yaml
+++ b/argocd/platform/istio/security.yaml
@@ -15,6 +15,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'istio-security-{{.env}}'
@@ -27,7 +28,7 @@ spec:
     spec:
       project: platform
       source:
-        repoURL: https://github.com/PodYourLife/k8s-platform.git
+        repoURL: '{{.repoUrl}}'
         targetRevision: '{{.targetRevision}}'
         path: istio/security
       destination:

--- a/argocd/platform/istio/telemetry.yaml
+++ b/argocd/platform/istio/telemetry.yaml
@@ -14,6 +14,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'istio-telemetry-{{.env}}'
@@ -25,7 +26,7 @@ spec:
     spec:
       project: platform
       source:
-        repoURL: https://github.com/PodYourLife/k8s-platform.git
+        repoURL: '{{.repoUrl}}'
         targetRevision: '{{.targetRevision}}'
         path: istio/telemetry
       destination:

--- a/argocd/platform/kyverno/policies.yaml
+++ b/argocd/platform/kyverno/policies.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   project: platform
   source:
-    repoURL: https://github.com/PodYourLife/k8s-platform.git
+    repoURL: __REPO_URL__
     targetRevision: __TARGET_REVISION__
     path: kubernetes/policies
   destination:

--- a/argocd/platform/monitoring/dashboards.yaml
+++ b/argocd/platform/monitoring/dashboards.yaml
@@ -22,6 +22,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'grafana-dashboards-{{.env}}'
@@ -33,7 +34,7 @@ spec:
     spec:
       project: platform
       source:
-        repoURL: https://github.com/PodYourLife/k8s-platform.git
+        repoURL: '{{.repoUrl}}'
         targetRevision: '{{.targetRevision}}'
         path: kubernetes/manifests/monitoring/dashboards
       destination:

--- a/argocd/platform/monitoring/datasources.yaml
+++ b/argocd/platform/monitoring/datasources.yaml
@@ -19,6 +19,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'grafana-datasources-{{.env}}'
@@ -30,7 +31,7 @@ spec:
     spec:
       project: platform
       source:
-        repoURL: https://github.com/PodYourLife/k8s-platform.git
+        repoURL: '{{.repoUrl}}'
         targetRevision: '{{.targetRevision}}'
         path: kubernetes/manifests/monitoring/datasources
       destination:

--- a/argocd/platform/monitoring/loki.yaml
+++ b/argocd/platform/monitoring/loki.yaml
@@ -19,6 +19,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'loki-{{.env}}'
@@ -37,7 +38,7 @@ spec:
             releaseName: loki
             valueFiles:
               - $values/kubernetes/helm/monitoring/loki-values.yaml
-        - repoURL: https://github.com/PodYourLife/k8s-platform.git
+        - repoURL: '{{.repoUrl}}'
           targetRevision: '{{.targetRevision}}'
           ref: values
       destination:

--- a/argocd/platform/monitoring/prometheus.yaml
+++ b/argocd/platform/monitoring/prometheus.yaml
@@ -23,6 +23,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'prometheus-{{.env}}'
@@ -42,7 +43,7 @@ spec:
             valueFiles:
               - $values/kubernetes/helm/monitoring/prometheus-values.yaml
               - $values/kubernetes/helm/monitoring/grafana-values.yaml
-        - repoURL: https://github.com/PodYourLife/k8s-platform.git
+        - repoURL: '{{.repoUrl}}'
           targetRevision: '{{.targetRevision}}'
           ref: values
       destination:

--- a/argocd/platform/monitoring/promtail.yaml
+++ b/argocd/platform/monitoring/promtail.yaml
@@ -17,6 +17,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'promtail-{{.env}}'
@@ -35,7 +36,7 @@ spec:
             releaseName: promtail
             valueFiles:
               - $values/kubernetes/helm/monitoring/promtail-values.yaml
-        - repoURL: https://github.com/PodYourLife/k8s-platform.git
+        - repoURL: '{{.repoUrl}}'
           targetRevision: '{{.targetRevision}}'
           ref: values
       destination:

--- a/argocd/platform/monitoring/servicemonitors.yaml
+++ b/argocd/platform/monitoring/servicemonitors.yaml
@@ -20,6 +20,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'monitoring-servicemonitors-{{.env}}'
@@ -31,7 +32,7 @@ spec:
     spec:
       project: platform
       source:
-        repoURL: https://github.com/PodYourLife/k8s-platform.git
+        repoURL: '{{.repoUrl}}'
         targetRevision: '{{.targetRevision}}'
         path: kubernetes/manifests/monitoring/servicemonitors
       destination:

--- a/argocd/platform/namespaces.yaml
+++ b/argocd/platform/namespaces.yaml
@@ -19,6 +19,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'namespaces-{{.env}}'
@@ -35,7 +36,7 @@ spec:
           jsonPointers:
             - /metadata/annotations
       source:
-        repoURL: https://github.com/PodYourLife/k8s-platform.git
+        repoURL: '{{.repoUrl}}'
         targetRevision: '{{.targetRevision}}'
         path: kubernetes/namespaces
       destination:

--- a/argocd/platform/opencost/opencost.yaml
+++ b/argocd/platform/opencost/opencost.yaml
@@ -22,6 +22,7 @@ spec:
             targetRevision: __TARGET_REVISION__
             awsRegion: __AWS_REGION__
             esoIrsaRoleArn: __ESO_IRSA_ROLE_ARN__
+            repoUrl: __REPO_URL__
   template:
     metadata:
       name: 'opencost-{{.env}}'
@@ -42,7 +43,7 @@ spec:
             valueFiles:
               - $values/kubernetes/helm/monitoring/opencost-values.yaml
         # Values reference — pulled from the GitOps repo
-        - repoURL: https://github.com/PodYourLife/k8s-platform.git
+        - repoURL: '{{.repoUrl}}'
           targetRevision: '{{.targetRevision}}'
           ref: values
       destination:


### PR DESCRIPTION
…in 15 ApplicationSets

## What

<!-- Une phrase décrivant ce que ce PR fait. -->

## Why

<!-- Contexte : pourquoi ce changement est nécessaire. -->

## Changes

<!-- Liste des fichiers modifiés et leur raison d'être. -->

- `path/to/file` — reason

## Checklist

- [ ] Branch is based on latest `main` (`git log --oneline main..HEAD`)
- [ ] No env-specific values on `main`-bound files
  ```bash
  grep -r "env: dev\|eu-west-3\|k8s-platform-dev\|esoIrsaRoleArn: \"\"" argocd/ kubernetes/helm/
  ```
- [ ] No unreplaced placeholder in manifests (only allowed in ApplicationSet `elements:`)
  ```bash
  grep -r "__ENV__\|__CLUSTER_NAME__" kubernetes/manifests/ kubernetes/helm/
  ```
- [ ] Commit messages follow Conventional Commits (`type(scope): description`)
- [ ] No file exceeds 200 lines (`find . -name "*.yaml" -o -name "*.go" | xargs wc -l | sort -rn | head -20`)
- [ ] No secrets or credentials committed (`git diff main --name-only | xargs grep -l "password\|secret\|token\|key" 2>/dev/null`)
- [ ] ArgoCD wave order documented in comments if sync order matters
- [ ] SRP respected — one file, one responsibility

## Testing

<!-- Comment as-tu validé ce changement ? -->

- [ ] `kubectl apply --dry-run=server` on changed manifests
- [ ] ArgoCD sync validated on local cluster (Kind)
- [ ] No new CrashLoopBackOff or ImagePullBackOff after sync

## Notes for reviewer

<!-- Tout ce qui aide le reviewer à comprendre les choix techniques. -->
