### PR TITLE
feat(terraform/platform/dev): provision QuanvNN datasets S3 bucket and IRSA role

### DIFF
--- a/terraform/domains/platform/dev/irsa.tf
+++ b/terraform/domains/platform/dev/irsa.tf
@@ -1,5 +1,5 @@
 # irsa.tf
-# Responsibility: IRSA roles for platform workloads (ArgoCD image updater, etc.)
+# Responsibility: IRSA roles for platform workloads (ArgoCD image updater, QuanvNN, etc.)
 # Cluster-level IRSA (ESO, Autoscaler) live in _core/shared/dev/iam.tf
 
 # ── ArgoCD image updater ───────────────────────────────────────────────────────
@@ -32,5 +32,38 @@ module "irsa_argocd_image_updater" {
   tags = {
     Environment = var.environment
     Component   = "argocd-image-updater"
+  }
+}
+
+# ── QuanvNN ML pipeline ────────────────────────────────────────────────────────
+# Read-only access to the QuanvNN datasets bucket (see s3.tf).
+# Bound to ServiceAccount system:serviceaccount:ml:quanvnn-sa — the SA name is the
+# contract between this role and the ml-batch-job Helm chart's ServiceAccount template.
+
+module "irsa_quanvnn" {
+  source = "../../../_core/modules/aws/irsa"
+
+  cluster_oidc_issuer_url = local.cluster_oidc_issuer_url
+  role_name               = "${local.cluster_id}-quanvnn-role"
+  namespace               = "ml"
+  service_account_name    = "quanvnn-sa"
+
+  policy_statements = [
+    {
+      effect    = "Allow"
+      actions   = ["s3:ListBucket"]
+      resources = [aws_s3_bucket.quanvnn_datasets.arn]
+    },
+    {
+      effect    = "Allow"
+      actions   = ["s3:GetObject"]
+      resources = ["${aws_s3_bucket.quanvnn_datasets.arn}/*"]
+    },
+  ]
+
+  tags = {
+    Environment = var.environment
+    Component   = "quanvnn"
+    Workload    = "ml"
   }
 }

--- a/terraform/domains/platform/dev/outputs.tf
+++ b/terraform/domains/platform/dev/outputs.tf
@@ -25,3 +25,8 @@ output "quanvnn_datasets_bucket_name" {
   description = "Name of the QuanvNN datasets S3 bucket"
   value       = aws_s3_bucket.quanvnn_datasets.bucket
 }
+
+output "quanvnn_irsa_role_arn" {
+  description = "IRSA role ARN for the QuanvNN ServiceAccount (ml/quanvnn-sa) — read-only S3 access"
+  value       = module.irsa_quanvnn.role_arn
+}

--- a/terraform/domains/platform/dev/outputs.tf
+++ b/terraform/domains/platform/dev/outputs.tf
@@ -15,3 +15,13 @@ output "node_group_arns" {
   description = "Map of node group name → node group ARN"
   value       = { for k, v in module.node_groups : k => v.node_group_arn }
 }
+
+output "quanvnn_datasets_bucket_arn" {
+  description = "ARN of the QuanvNN datasets S3 bucket"
+  value       = aws_s3_bucket.quanvnn_datasets.arn
+}
+
+output "quanvnn_datasets_bucket_name" {
+  description = "Name of the QuanvNN datasets S3 bucket"
+  value       = aws_s3_bucket.quanvnn_datasets.bucket
+}

--- a/terraform/domains/platform/dev/s3.tf
+++ b/terraform/domains/platform/dev/s3.tf
@@ -1,0 +1,68 @@
+# s3.tf
+# Responsibility: S3 buckets for ML workloads on the dev environment.
+# QuanvNN datasets bucket — read-only access from the ml namespace via IRSA (see irsa.tf).
+
+# ── QuanvNN datasets bucket ────────────────────────────────────────────────────
+# Holds satellite imagery patches consumed by the QuanvNN training pipeline.
+# Read-only from the cluster — uploads happen out-of-band (operator from a workstation).
+
+resource "aws_s3_bucket" "quanvnn_datasets" {
+  bucket        = "podyourlife-quanvnn-datasets-dev"
+  force_destroy = false
+
+  tags = {
+    Component = "quanvnn-datasets"
+    Workload  = "ml"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "quanvnn_datasets" {
+  bucket = aws_s3_bucket.quanvnn_datasets.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "quanvnn_datasets" {
+  bucket = aws_s3_bucket.quanvnn_datasets.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "quanvnn_datasets" {
+  bucket = aws_s3_bucket.quanvnn_datasets.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "quanvnn_datasets" {
+  bucket = aws_s3_bucket.quanvnn_datasets.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "quanvnn_datasets" {
+  bucket = aws_s3_bucket.quanvnn_datasets.id
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Sprint 2A — Terraform-only infrastructure for the QuanvNN ML pipeline on dev.

- New S3 bucket `podyourlife-quanvnn-datasets-dev` for satellite imagery patches consumed by the QuanvNN training pipeline. Versioning + SSE-S3 + full public access block + `BucketOwnerEnforced` ownership + 90-day noncurrent version lifecycle.
- New IRSA role assumable by `system:serviceaccount:ml:quanvnn-sa` via the EKS OIDC provider. Read-only S3 access (`s3:ListBucket`, `s3:GetObject`) — no write or delete permissions.
- Three new outputs: `quanvnn_datasets_bucket_name`, `quanvnn_datasets_bucket_arn`, `quanvnn_irsa_role_arn`.

## Files in scope

- `terraform/domains/platform/dev/s3.tf` (new — 71 lines, 6 resources)
- `terraform/domains/platform/dev/irsa.tf` (modified — appends `module.irsa_quanvnn`, updates header comment)
- `terraform/domains/platform/dev/outputs.tf` (modified — appends 3 outputs alphabetically)

## Pattern adherence

The IRSA role uses the existing `_core/modules/aws/irsa` module (matching the `argocd_image_updater` IRSA already in the file), not raw `aws_iam_role` + `aws_iam_policy_document` resources. The module handles trust policy construction, OIDC subject pinning, policy attachment, and tagging in one block.

## Validation

- `terraform fmt -check -diff` — clean
- `terraform init -backend=false` — providers resolved (aws 5.100.0, tls 4.2.1)
- `terraform validate` — Success! The configuration is valid.

No `terraform apply` was run — out of Sprint 2A scope. Apply will happen via `platform-bot env apply --env dev` once the PR merges to `main` and the dev branch is re-hydrated.

## Out of scope (Sprint 2B and beyond)

- Helm values change in `kubernetes/helm/values/quanvnn-dev.yaml` to set `serviceAccount.irsaRoleArn` and the `S3_DATASETS_BUCKET` env var
- Bucket data upload (operator action from a workstation, AWS CLI)
- Any Go code in `platform-bot`

## Test plan

- [ ] CI: `terraform validate` job passes on the dev domain
- [ ] CI: `terraform fmt` job passes
- [ ] CI: `tflint` if configured passes
- [ ] After merge: hydrate dev branch and run `terraform plan` to confirm a clean creation diff (1 bucket + 5 bucket-config resources + 1 IAM role + 1 IAM policy + 1 attachment + 2 data sources)
- [ ] After apply: confirm bucket creation in eu-west-3 and IAM role visible with the expected trust policy subject `system:serviceaccount:ml:quanvnn-sa`