### PR TITLE
fix(terraform/platform/dev): interpolate var.environment in QuanvNN bucket name + add SSE-KMS TODO

### DIFF
--- a/terraform/domains/platform/dev/s3.tf
+++ b/terraform/domains/platform/dev/s3.tf
@@ -7,7 +7,7 @@
 # Read-only from the cluster — uploads happen out-of-band (operator from a workstation).
 
 resource "aws_s3_bucket" "quanvnn_datasets" {
-  bucket        = "podyourlife-quanvnn-datasets-dev"
+  bucket        = "podyourlife-quanvnn-datasets-${var.environment}"
   force_destroy = false
 
   tags = {
@@ -24,6 +24,8 @@ resource "aws_s3_bucket_versioning" "quanvnn_datasets" {
   }
 }
 
+# TODO(staging/prod): switch to SSE-KMS with a customer-managed key when
+# compliance_profile is "soc2" — AES256 (SSE-S3) is acceptable for dev only.
 resource "aws_s3_bucket_server_side_encryption_configuration" "quanvnn_datasets" {
   bucket = aws_s3_bucket.quanvnn_datasets.id
 


### PR DESCRIPTION
## Summary

Small follow-up to PR #39 addressing the two non-blocking 🟡 nits from `PR_39_REVIEW.md`:

- **Topic G** — interpolate `${var.environment}` into the QuanvNN bucket name instead of the hardcoded `"dev"` literal. Avoids a copy-paste hazard when this file is templated for staging/prod (a leaked `"dev"` literal in a non-dev bucket would be silent until apply-time).
- **Topic D / KMS hardening** — add a TODO flagging that AES256 (SSE-S3) is dev-only baseline; staging/prod under `compliance_profile = "soc2"` should switch to SSE-KMS with a customer-managed key.

## Safety

Both changes are **no-ops on dev**:

- `var.environment` defaults to `"dev"` and the dev `terraform.tfvars` sets `environment = "dev"`, so `"podyourlife-quanvnn-datasets-${var.environment}"` evaluates to the exact same byte string as the prior literal. Terraform will not replace the bucket.
- The TODO is a comment only.

## Test plan

- [x] `terraform fmt -check -diff s3.tf` clean
- [x] `terraform validate` succeeds
- [ ] After hydrate on dev branch: `terraform plan` shows zero changes for `aws_s3_bucket.quanvnn_datasets`
- [ ] No new resource replacements anywhere in the plan