### PR TITLE
feat(platform): k8s manifests for QuanvNN MVP (Sprint 2C)

### DIFF
--- a/argocd/platform/gpu/nvidia-device-plugin.yaml
+++ b/argocd/platform/gpu/nvidia-device-plugin.yaml
@@ -1,0 +1,66 @@
+# NVIDIA k8s-device-plugin — exposes GPUs to the kubelet as nvidia.com/gpu
+# Wave 2 — runs after istio-base/istiod/istio-cni (waves -2 to 0) so that
+# strict mTLS doesn't disrupt the device plugin's gRPC socket negotiation.
+# Without this DaemonSet, GPU Jobs stay Pending forever even after Cluster
+# Autoscaler provisions a g4dn node — kubelet never advertises the resource.
+#
+# Targets the GPU node group only via nodeSelector + matching toleration.
+# CPU nodes are unaffected — no DaemonSet pod is scheduled there.
+#
+# Ref: https://github.com/NVIDIA/k8s-device-plugin
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: nvidia-device-plugin
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - env: __ENV__
+            targetRevision: __TARGET_REVISION__
+            awsRegion: __AWS_REGION__
+  template:
+    metadata:
+      name: 'nvidia-device-plugin-{{.env}}'
+      namespace: argocd
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+      annotations:
+        argocd.argoproj.io/sync-wave: "2"
+    spec:
+      project: platform
+      source:
+        repoURL: https://nvidia.github.io/k8s-device-plugin
+        chart: nvidia-device-plugin
+        targetRevision: __NVIDIA_DEVICE_PLUGIN_VERSION__
+        helm:
+          releaseName: nvidia-device-plugin
+          values: |
+            # Restrict the DaemonSet to GPU nodes only — matches the
+            # node-group=gpu label set in terraform.tfvars node_groups.gpu.labels.
+            nodeSelector:
+              node-group: gpu
+
+            # Tolerate the GPU taint declared on the gpu nodegroup
+            # (terraform.tfvars: nvidia.com/gpu=true:NoSchedule).
+            tolerations:
+              - key: nvidia.com/gpu
+                operator: Equal
+                value: "true"
+                effect: NoSchedule
+
+            # No runtimeClassName override — EKS GPU AMIs ship the nvidia
+            # container runtime as the default runc shim. Setting this would
+            # break scheduling on stock AMIs.
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: kube-system
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=false
+          - ServerSideApply=true

--- a/argocd/platform/gpu/priority-classes.yaml
+++ b/argocd/platform/gpu/priority-classes.yaml
@@ -1,0 +1,54 @@
+# Cluster-scoped PriorityClasses for GPU workloads.
+#
+# Wave -2 — must be present before any pod that references them is
+# scheduled. The actual GPU workloads run much later (wave 9+ for
+# monitoring stack, then on-demand ML jobs), so wave -2 is comfortably
+# early. This wave parallels istio-base (CRDs) — no ordering conflict
+# since both are cluster-scoped resources with no inter-dependency.
+#
+# These resources are platform-owned (cluster-scoped) and therefore
+# cannot live in the chart-owned ml AppProject (whose
+# clusterResourceWhitelist is empty). The platform AppProject scope
+# owns them via this dedicated ApplicationSet.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: priority-classes
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - env: __ENV__
+            targetRevision: __TARGET_REVISION__
+            repoUrl: __REPO_URL__
+  template:
+    metadata:
+      name: 'priority-classes-{{.env}}'
+      namespace: argocd
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+      annotations:
+        argocd.argoproj.io/sync-wave: "-2"
+    spec:
+      project: platform
+      source:
+        repoURL: '{{.repoUrl}}'
+        targetRevision: '{{.targetRevision}}'
+        path: kubernetes/manifests/priority-classes
+        directory:
+          recurse: false
+      destination:
+        # PriorityClasses are cluster-scoped — destination namespace is
+        # ignored by the API but ArgoCD requires the field. kube-system
+        # is the conventional placeholder for cluster-scoped manifests.
+        server: https://kubernetes.default.svc
+        namespace: kube-system
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=false
+          - ServerSideApply=true

--- a/argocd/projects/platform.yaml
+++ b/argocd/projects/platform.yaml
@@ -23,6 +23,7 @@ spec:
     - https://kyverno.github.io/kyverno/
     - https://opencost.github.io/opencost-helm-chart
     - https://charts.jetstack.io
+    - https://nvidia.github.io/k8s-device-plugin
 
   destinations:
     - namespace: istio-system
@@ -86,6 +87,8 @@ spec:
       kind: ClusterIssuer
     - group: external-secrets.io
       kind: ClusterSecretStore
+    - group: scheduling.k8s.io
+      kind: PriorityClass
 
   namespaceResourceWhitelist:
     - group: "*"

--- a/kubernetes/helm/ml-batch-job/templates/external-secret.yaml
+++ b/kubernetes/helm/ml-batch-job/templates/external-secret.yaml
@@ -1,0 +1,50 @@
+{{/*
+external-secret.yaml — optional GHCR imagePullSecret provisioning.
+Conditional behind .Values.imagePullSecret.enabled (default false).
+
+Resolves AUDIT_QUANVNN_MVP.md MEDIUM finding — the chart's job-cpu.yaml
+and job-gpu.yaml reference imagePullSecrets[*].name = .Values.imagePullSecret.secretName,
+but no template existed to provision the underlying Secret. Operators
+had to pre-create it manually with kubectl.
+
+When opted in, this template renders an ExternalSecret that ESO syncs
+from AWS Secrets Manager into a Secret of type kubernetes.io/dockerconfigjson.
+The remote secret in AWS SM must carry a JSON property named "dockerconfig"
+whose value is the full dockerconfigjson blob (escaped JSON inside JSON).
+
+ESO API version external-secrets.io/v1beta1 — matches the platform's
+pinned ESO 0.10.7 (platform.yaml versions.external_secrets) and the
+existing kubernetes/manifests/secrets/grafana-admin-externalsecret.yaml.
+*/}}
+{{- if .Values.imagePullSecret.enabled -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.imagePullSecret.secretName }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "ml-batch-job.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.imagePullSecret.secretStoreRef.name }}
+    kind: {{ .Values.imagePullSecret.secretStoreRef.kind }}
+  target:
+    name: {{ .Values.imagePullSecret.secretName }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        # ESO evaluates this template at sync time — the raw braces below
+        # must reach the rendered manifest as a literal Go template.
+        # Helm-escaped via backticks so the chart pass-through doesn't
+        # consume the inner braces.
+        .dockerconfigjson: |
+          {{ `{{ .dockerconfig | toString }}` }}
+  data:
+    - secretKey: dockerconfig
+      remoteRef:
+        key: {{ .Values.imagePullSecret.awsSecretPath | quote }}
+        property: dockerconfig
+{{- end }}

--- a/kubernetes/helm/ml-batch-job/values.schema.json
+++ b/kubernetes/helm/ml-batch-job/values.schema.json
@@ -57,8 +57,18 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
-        "secretName": { "type": "string" },
-        "awsSecretPath": { "type": "string" }
+        "secretName": { "type": "string", "minLength": 1 },
+        "awsSecretPath": { "type": "string" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "kind": {
+              "type": "string",
+              "enum": ["ClusterSecretStore", "SecretStore"]
+            }
+          }
+        }
       }
     },
     "serviceAccount": {

--- a/kubernetes/helm/ml-batch-job/values.yaml
+++ b/kubernetes/helm/ml-batch-job/values.yaml
@@ -43,10 +43,27 @@ image:
 
 # Creates an ExternalSecret that syncs the GHCR pull token from AWS Secrets
 # Manager into a native Kubernetes Secret. ESO must be installed on the cluster.
+#
+# Default is opt-out (enabled: false) — consumers who pre-create the Secret
+# externally are unaffected. Set enabled: true in the per-app values file
+# (e.g. quanvnn-dev.yaml) to provision the ExternalSecret via this chart.
+#
+# When enabled:
+#   - secretName    : K8s Secret name written by ESO; must match the
+#                     reference in job-cpu.yaml/job-gpu.yaml imagePullSecrets.
+#   - awsSecretPath : key path in AWS Secrets Manager. The remote secret must
+#                     contain a JSON property named "dockerconfig" whose value
+#                     is the dockerconfigjson contents.
+#   - secretStoreRef: ClusterSecretStore (default) or SecretStore reference.
+#                     Canonical name "aws-secrets-manager" is the platform
+#                     default — bound to AWS SM via IRSA on ESO.
 imagePullSecret:
-  enabled: true
+  enabled: false
   secretName: "ghcr-pull-secret"
   awsSecretPath: ""
+  secretStoreRef:
+    name: "aws-secrets-manager"
+    kind: "ClusterSecretStore"
 
 # A dedicated ServiceAccount is always created for isolation.
 # Set irsaRoleArn to enable IRSA — grants the pod AWS API access (e.g. S3)

--- a/kubernetes/helm/values/quanvnn-dev.yaml
+++ b/kubernetes/helm/values/quanvnn-dev.yaml
@@ -56,9 +56,9 @@ imagePullSecret:
 # SERVICE ACCOUNT + IRSA
 # ─────────────────────────────────────────────────────────────────────────────
 # IRSA Role ARN provisioned by terraform/domains/platform — grants S3 access.
-# Replace __IRSA_ROLE_ARN__ with the actual ARN at init time (platform-bot).
+# Replace __QUANVNN_IRSA_ROLE_ARN__ with the actual ARN at init time (platform-bot).
 serviceAccount:
-  irsaRoleArn: "__IRSA_ROLE_ARN__"
+  irsaRoleArn: "__QUANVNN_IRSA_ROLE_ARN__"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # STORAGE

--- a/kubernetes/manifests/priority-classes/gpu-batch-priority.yaml
+++ b/kubernetes/manifests/priority-classes/gpu-batch-priority.yaml
@@ -1,0 +1,16 @@
+# gpu-batch-priority — default priority for GPU batch training jobs.
+# Below gpu-high-priority (preemptible by inference workloads), above
+# the implicit default of 0 used by unprioritized pods.
+#
+# QuanvNN ml-batch-job pod templates will reference this class via
+# spec.priorityClassName in Sprint 3.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: gpu-batch-priority
+  labels:
+    platform.podyourlife.io/domain: ml
+    platform.podyourlife.io/priority-tier: batch
+value: 500
+globalDefault: false
+description: "Batch GPU workloads (QuanvNN training). Preemptible by gpu-high-priority."

--- a/kubernetes/manifests/priority-classes/gpu-high-priority.yaml
+++ b/kubernetes/manifests/priority-classes/gpu-high-priority.yaml
@@ -1,0 +1,17 @@
+# gpu-high-priority — reserved for time-sensitive GPU workloads
+# (e.g. inference, on-call experiments). Higher priority than
+# gpu-batch-priority — preempts batch jobs when GPU capacity is constrained.
+#
+# value 1000 sits well below the cluster-default system tiers
+# (system-cluster-critical = 2000000000) but well above the implicit
+# default of 0 used by unprioritized pods.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: gpu-high-priority
+  labels:
+    platform.podyourlife.io/domain: ml
+    platform.podyourlife.io/priority-tier: high
+value: 1000
+globalDefault: false
+description: "High-priority GPU workloads (inference, time-sensitive). Preempts gpu-batch-priority."

--- a/kubernetes/policies/check-image-registry.yaml
+++ b/kubernetes/policies/check-image-registry.yaml
@@ -59,3 +59,6 @@ spec:
                   - key: "{{ element.image }}"
                     operator: NotEquals
                     value: "ghcr.io/opencost/*"
+                  - key: "{{ element.image }}"
+                    operator: NotEquals
+                    value: "public.ecr.aws/aws-cli/*"

--- a/platform.yaml
+++ b/platform.yaml
@@ -20,6 +20,7 @@ versions:
   external_secrets: "0.10.7"
   opencost: "1.42.0"
   cert_manager: "v1.20.0"
+  nvidia_device_plugin: "0.19.1"   # → __NVIDIA_DEVICE_PLUGIN_VERSION__ (Sprint 2D bot mapping pending)
 
 accounts:
   dev: ""


### PR DESCRIPTION
## Summary
Sprint 2C from `roadmap.md` — Kubernetes manifests + Helm chart only.
Five distinct commits, each addressing one Sprint 2C item.

Pre-flight: integrity review GO_WITH_WARNINGS, 0 blockers.

## Commits
- `7345510` fix(values): rename IRSA placeholder for QuanvNN
- `94697b7` feat(argocd): NVIDIA device plugin ApplicationSet
- `0d02210` feat(scheduling): GPU PriorityClasses + ApplicationSet
- `0ec75cf` feat(kyverno): allow public.ecr.aws/aws-cli for initContainers
- `a4d5980` feat(chart): conditional ExternalSecret for ghcr-pull-secret

## Audit findings addressed
- HIGH (audit §3.2): NVIDIA device plugin missing → ApplicationSet
  added at sync-wave 2.
- MEDIUM (audit §3.6): chart references ghcr-pull-secret without an
  ExternalSecret template → conditional template added (opt-in).
- Sprint 2C item 2.4: `__IRSA_ROLE_ARN__` → `__QUANVNN_IRSA_ROLE_ARN__`,
  aligning with platform-bot (PR #7, ffd16f5).
- Sprint 2C item 2.7: Kyverno allowlist extended for `public.ecr.aws/aws-cli`
  (Sprint 3 dataSync initContainer).

## Identity chain (audit §6)
- SA: `quanvnn-sa` in `ml`. Locked by chart helpers (verified via
  `helm template` in pre-2C integrity review).
- IRSA placeholder: `__QUANVNN_IRSA_ROLE_ARN__` (this PR).
- Bucket placeholder: `__QUANVNN_DATASETS_BUCKET_NAME__` (NOT consumed
  in this PR — Sprint 3 will use it). Note: canonical name uses NAME
  suffix and plural \"datasets\".

## Validation
- `helm lint` passes with `quanvnn-dev.yaml` (after C1 and after C5).
- `helm template` renders zero `ExternalSecret` with chart defaults,
  exactly one when `imagePullSecret.enabled=true`.
- `helm template` escape verification: rendered `.dockerconfigjson`
  body contains literal `{{ .dockerconfig | toString }}` for ESO to
  evaluate at sync time.
- YAML structural validation via Ruby `YAML.load_file` on all new
  ApplicationSets and PriorityClass manifests.
- No `kubectl apply` against a live cluster — Sprint 2 orchestration
  handles that via the bot.

## Deviations from prompt — justified
1. **AS path**: prompt said `argocd/applicationsets/`; the repo
   convention is `argocd/platform/<domain>/<name>.yaml`. Used
   `argocd/platform/gpu/` for both new ASes (NVIDIA + PriorityClasses).
2. **`imagePullSecret` schema**: prompt suggested new field names
   (`create`, `name`, `secretStoreRef`, `remoteSecretKey`); existing
   chart already had `enabled`, `secretName`, `awsSecretPath`. Reused
   the existing names, flipped default `enabled: true → false` (safer
   opt-in), added `secretStoreRef` only.

## Follow-ups (separate sessions)
- **Sprint 2D (platform-bot)**: bot's `internal/gitops/placeholders.go`
  must learn `versions.nvidia_device_plugin` →
  `__NVIDIA_DEVICE_PLUGIN_VERSION__`. Until shipped, the NVIDIA AS
  carries a literal placeholder and won't sync — flagged in commit
  message of `94697b7`.
- **AWS SM seed (operator, manual)**: before `bootstrap eks --env dev`,
  seed the secret at `platform/dev/ghcr-pull-token` (or
  `platform/ghcr-pull-token` per current quanvnn-dev value) with a
  JSON object containing a `dockerconfig` key.

## Out of scope
- AWS Secrets Manager pre-seed (manual AWS CLI step — roadmap §2.9).
- Bot orchestration: env hydrate → plan → apply --local → bootstrap
  eks → re-hydrate (roadmap §2.12-2.17).
- Sprint 3 dataSync initContainer (consumes the bucket placeholder
  and the new Kyverno allowlist entry).

## Review-driven follow-up commits
- `e402435` fix(argocd): extend platform project for Sprint 2C ASes
  (resolves F1 + F2 from PR_41_REVIEW.md — adds
  `https://nvidia.github.io/k8s-device-plugin` to `sourceRepos` and
  `scheduling.k8s.io/PriorityClass` to `clusterResourceWhitelist` on the
  `platform` AppProject).
